### PR TITLE
Allow config override and publish types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It uses [tocbot](https://github.com/tscanlin/tocbot) under the hood.
 npm i -D storybook-docs-toc
 ```
 
+Be aware that `styled-components` is a peer dependency.
+
 ## Usage
 
 Add this to your preview.js file
@@ -47,10 +49,14 @@ export const parameters = {
 +                    <BackToTop className="sbdocs sbdocs-top--custom" />
 +                </DocsContainer>
 +            </React.Fragment>
-+        ),          
++        ),
     },
 };
 ```
+
+## Configuration
+
+You can override the default selectors for tocbot via the `config` prop on `DocsContainerHOC` or `TableOfContents`. These also take a custom `title`.
 
 ## Customization
 
@@ -58,18 +64,18 @@ Some CSS custom properties are available to customize the styles of the table of
 
 ```css
 .sbdocs.sbdocs-toc--custom {
-    --toc-color: #202020;
-    --toc-background: #fff;
-    --toc-indicator-color: #efefef;
-    --toc-indicator-color--active: #fbd476;
+  --toc-color: #202020;
+  --toc-background: #fff;
+  --toc-indicator-color: #efefef;
+  --toc-indicator-color--active: #fbd476;
 }
 
 .sbdocs.sbdocs-top--custom {
-    --toc-button-color: #66bf3cff;
-    --toc-button-color--hover: #66bf3ccc;
-    --toc-button-color--active: #66bf3caa;
-    --toc-button-background: #e7fdd8ff;
-    --toc-button-background--hover: #e7fdd8cc;
-    --toc-button-background--active: #e7fdd8aa;
+  --toc-button-color: #66bf3cff;
+  --toc-button-color--hover: #66bf3ccc;
+  --toc-button-color--active: #66bf3caa;
+  --toc-button-background: #e7fdd8ff;
+  --toc-button-background--hover: #e7fdd8cc;
+  --toc-button-background--active: #e7fdd8aa;
 }
 ```

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "1.6.1",
   "description": "Table of contents addon for Storybook Docs",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "storybook": {
     "displayName": "Table of contents",
     "icon": "https://raw.githubusercontent.com/frassinier/storybook-docs-toc/master/icon.png"
   },
   "scripts": {
     "watch": "babel --watch src ---out-dir dist --extensions '.ts,.tsx'",
-    "build": "babel src --out-dir dist --extensions '.ts,.tsx'",
+    "build:js": "babel src --out-dir dist --extensions '.ts,.tsx'",
+    "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist",
+    "build": "yarn build:js && yarn build:types",
     "tsc": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",

--- a/src/components/DocsContainerHOC.tsx
+++ b/src/components/DocsContainerHOC.tsx
@@ -1,21 +1,22 @@
-import React, { FunctionComponent } from "react";
+import React, { ComponentProps, FunctionComponent } from "react";
 import { DocsContainer, DocsContainerProps } from "@storybook/addon-docs";
 import TableOfContents from "./TableOfContents";
 import BackToTop from "./BackToTop";
 
-const DocsContainerHOC: FunctionComponent<DocsContainerProps> = ({
+type Props = DocsContainerProps &
+  Pick<ComponentProps<typeof TableOfContents>, "title" | "config">;
+
+const DocsContainerHOC: FunctionComponent<Props> = ({
   children,
+  title,
+  config,
   ...rest
-}) => {
-  return (
-    <React.Fragment>
-      <DocsContainer {...rest}>
-        <TableOfContents />
-        {children}
-        <BackToTop />
-      </DocsContainer>
-    </React.Fragment>
-  );
-};
+}) => (
+  <DocsContainer {...rest}>
+    <TableOfContents title={title} config={config} />
+    {children}
+    <BackToTop />
+  </DocsContainer>
+);
 
 export default DocsContainerHOC;

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -80,22 +80,33 @@ const NavHeader = styled.header.attrs({
   margin-bottom: 8px;
 `;
 
-const configuration = {
+const defaultConfiguration = {
   tocSelector: ".js-toc",
   contentSelector: ".sbdocs-content",
   headingSelector: ".sbdocs-h2",
 };
 
-type TableOfContentsProps = React.PropsWithChildren<any> & {
+type TableOfContentsProps = React.PropsWithChildren<{
   title?: React.ReactNode;
-};
+  config?: tocbot.IStaticOptions;
+}>;
 
 const TableOfContents = React.forwardRef(
   (
-    { title = "Table of contents", children, ...rest }: TableOfContentsProps,
+    {
+      title = "Table of contents",
+      config = {},
+      children,
+      ...rest
+    }: TableOfContentsProps,
     ref: React.Ref<HTMLDivElement>
   ) => {
     const [headings, setHeadings] = React.useState<Element[]>([]);
+
+    const configuration = {
+      ...defaultConfiguration,
+      ...config,
+    };
 
     React.useEffect(() => {
       const h2 = Array.from(


### PR DESCRIPTION
This builds on https://github.com/frassinier/storybook-docs-toc/pull/15, but with some additional changes:

- Update `README.md` to document `styled-components` peer dependency.
- Update `README.md` to document how to override default toc configuration.
- Generate type declarations as part of `yarn build` to include those in the published package.
- Update `DocsContainerHOC` to pass through existing `title` and new `config` property to `TableOfContents`.
- Update `TableOfContents` to not only use custom config for `tocbot.init` - like https://github.com/frassinier/storybook-docs-toc/pull/15/files does - but also for querying for h2s (or else TOC will never show).